### PR TITLE
Add Stream Deck+ Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@rweich/streamdeck-events": "^4.0.0",
-    "@sinclair/typebox": "^0.24.48",
+    "@rweich/streamdeck-events": "^4.1.0",
+    "@sinclair/typebox": "^0.24.49",
     "ajv": "^8.9.0",
     "eventemitter3": "^4.0.7",
     "isomorphic-ws": "^5.0.0",

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -1,3 +1,9 @@
+import {
+  GenericLayoutFeedback,
+  LayoutFeedback,
+  LayoutFeedbackKey,
+} from '@rweich/streamdeck-events/dist/StreamdeckTypes/Received/Feedback/LayoutFeedback';
+
 import AbstractStreamdeckConnector from './AbstractStreamdeckConnector';
 import { PluginEvents } from './events/Events';
 
@@ -16,6 +22,31 @@ export default class Plugin extends AbstractStreamdeckConnector {
    */
   public sendToPropertyInspector(context: string, payload: Record<string, unknown>): void {
     this.sendToStreamdeck(this.sentEventFactory.sendToPropertyInspector('', context, payload));
+  }
+
+  /**
+   * Sends a command to the Stream Deck to update the Feedback displayed for a specific dial.
+   *
+   * Feedback payloads must conform to (at least) the `GenericLayoutFeedback` type for any updates, but stricter types
+   * are accepted so long as they also satisfy the requirements of this type.
+   *
+   * @param payload The feedback object to send to the Stream Deck, based on at least GenericLayoutFeedback
+   * @param context The context / id of the current action / button.
+   */
+  public setFeedback(payload: LayoutFeedback | GenericLayoutFeedback, context: string): void {
+    this.sendToStreamdeck(this.sentEventFactory.setFeedback(payload, context));
+  }
+
+  /**
+   * Sends a command to the Stream Deck to update the Feedback Layout for a specific dial.
+   *
+   * Layouts may either be a hardcoded layout ID or a path (relative to plugin root) to a layout JSON. This library
+   * will perform *no validation* whether a specific layout is valid or not.
+   * @param layout A layout key or path to use as the layout for this dial.
+   * @param context The context / id of the current action / button.
+   */
+  public setFeedbackLayout(layout: LayoutFeedbackKey | string, context: string): void {
+    this.sendToStreamdeck(this.sentEventFactory.setFeedbackLayout(layout, context));
   }
 
   /**

--- a/src/pi/ActionInfo.ts
+++ b/src/pi/ActionInfo.ts
@@ -1,3 +1,4 @@
+import { ControllerType } from '@rweich/streamdeck-events/dist/Events/Received/Plugin/ControllerType';
 import { Static, Type } from '@sinclair/typebox';
 
 import assertType from '../helper/AssertType';
@@ -7,6 +8,7 @@ const ActionInfoType = Type.Object({
   context: Type.String(),
   device: Type.String(),
   payload: Type.Object({
+    controller: Type.Optional(Type.Enum(ControllerType)),
     coordinates: Type.Optional(
       Type.Object({
         column: Type.Number(),
@@ -37,6 +39,17 @@ export default class ActionInfo {
 
   public get device(): string {
     return this.actionInfo.device;
+  }
+
+  /**
+   * Return the controller type associated with this specific property inspector. Can be used to determine if this PI
+   * controls a standard button or a rotary dial. This will not change during the PI's lifecycle.
+   *
+   * For plugins running on API v5, this will always return "Keypad".
+   * @returns {ControllerType} The controller type (either "Keypad" or "Encoder") of this action's event.
+   */
+  public get controller(): ControllerType {
+    return this.actionInfo.payload.controller ?? ControllerType.Keypad;
   }
 
   public get column(): number | undefined {

--- a/test/PluginTest.ts
+++ b/test/PluginTest.ts
@@ -16,6 +16,8 @@ import {
   ShowOkType,
   SwitchToProfileType,
 } from '@rweich/streamdeck-events/dist/StreamdeckTypes/Received';
+import { SetFeedbackLayoutType } from '@rweich/streamdeck-events/dist/StreamdeckTypes/Received/SetFeedbackLayoutType';
+import { SetFeedbackType } from '@rweich/streamdeck-events/dist/StreamdeckTypes/Received/SetFeedbackType';
 import { expect } from 'chai';
 import { default as EventEmitter } from 'eventemitter3';
 import { dummyLogger } from 'ts-log';
@@ -146,6 +148,26 @@ describe('Plugin test', () => {
         done();
       });
       plugin.sendToPropertyInspector('contextt', { the: 'payload' });
+    });
+    it('should send the SetFeedbackEvent', (done) => {
+      ws.once('message', (json) => {
+        const data: SetFeedbackType = JSON.parse(json.toString());
+        expect(data.event).to.equal('setFeedback');
+        expect(data.context).to.equal('mycontext');
+        expect(data.payload.title).to.equal('Hello, world');
+        done();
+      });
+      plugin.setFeedback({ title: 'Hello, world' }, 'mycontext');
+    });
+    it('should send the SetFeedbackLayoutEvent', (done) => {
+      ws.once('message', (json) => {
+        const data: SetFeedbackLayoutType = JSON.parse(json.toString());
+        expect(data.event).to.equal('setFeedbackLayout');
+        expect(data.context).to.equal('buddon');
+        expect(data.payload.layout).to.equal('layouts/layoutv2.json');
+        done();
+      });
+      plugin.setFeedbackLayout('layouts/layoutv2.json', 'buddon');
     });
     it('should send the SetGlobalSettingsEvent', (done) => {
       ws.once('message', (json) => {

--- a/test/PropertyInspectorTest.ts
+++ b/test/PropertyInspectorTest.ts
@@ -1,6 +1,7 @@
 import 'mocha';
 
 import { EventsReceived, EventsSent } from '@rweich/streamdeck-events';
+import { ControllerType } from '@rweich/streamdeck-events/dist/Events/Received/Plugin/ControllerType';
 import {
   GetGlobalSettingsType,
   GetSettingsType,
@@ -97,6 +98,46 @@ describe('PropertyInspector test', () => {
       expect(pi.actionInfo?.column).to.be.undefined;
       expect(pi.actionInfo?.row).to.be.undefined;
       expect(Object.keys(pi.actionInfo?.settings as Record<string, unknown>)).to.be.length(0);
+      closeServer(server);
+      done();
+    });
+    connector(
+      '23456',
+      'uid',
+      'register',
+      'info',
+      '{"action":"abcdef","context":"cdef","device":"bcdef","payload":{"settings":{}}}',
+    );
+  });
+  it('should have a controller value set if passed (API 6)', (done) => {
+    const emitter = new EventEmitter();
+    const server = new Server({ host: '127.0.0.1', port: 23_456 });
+    const pi = new PropertyInspector(emitter, new EventsReceived(), new EventsSent(), dummyLogger);
+    const connector = pi.createStreamdeckConnector();
+    emitter.on('websocketOpen', () => {
+      expect(pi.actionInfo?.controller).to.equal(ControllerType.Encoder);
+      expect(pi.actionInfo?.controller).to.equal('Encoder');
+
+      closeServer(server);
+      done();
+    });
+    connector(
+      '23456',
+      'uid',
+      'register',
+      'info',
+      '{"action":"abcde","context":"cde","device":"bcde","payload":{"controller":"Encoder","settings":{}}}',
+    );
+  });
+  it('should default to controller type "Keypad" if unset', (done) => {
+    const emitter = new EventEmitter();
+    const server = new Server({ host: '127.0.0.1', port: 23_456 });
+    const pi = new PropertyInspector(emitter, new EventsReceived(), new EventsSent(), dummyLogger);
+    const connector = pi.createStreamdeckConnector();
+    emitter.on('websocketOpen', () => {
+      expect(pi.actionInfo?.controller).to.equal(ControllerType.Keypad);
+      expect(pi.actionInfo?.controller).to.equal('Keypad');
+
       closeServer(server);
       done();
     });

--- a/test/ReadmeTests.ts
+++ b/test/ReadmeTests.ts
@@ -45,6 +45,16 @@ describe('Tests that the snippets in the Readme.md dont throw errors', () => {
     test('the deviceDidDisconnect snippet', () => {
       plugin.on('deviceDidDisconnect', ({ device }) => console.log(`device with id ${device} was unplugged`));
     });
+    test('the dialPress snippet', () => {
+      plugin.on('dialPress', ({ pressed }) => {
+        console.log(`a dial was ${pressed ? 'pressed' : 'released'}`);
+      });
+    });
+    test('the dialRotate snippet', () => {
+      plugin.on('dialRotate', ({ ticks, pressed }) => {
+        console.log(`a dial was rotated ${ticks} ticks. It ${pressed ? 'was' : 'was not'} pressed.`);
+      });
+    });
     test('the didReceiveGlobalSettings snippet', () => {
       plugin.on('didReceiveGlobalSettings', ({ settings }) => console.log('got settings', settings));
     });
@@ -77,6 +87,11 @@ describe('Tests that the snippets in the Readme.md dont throw errors', () => {
     test('the titleParametersDidChange snippet', () => {
       plugin.on('titleParametersDidChange', ({ fontSize }) => console.log(`new title/params with size ${fontSize}!`));
     });
+    test('the touchTap snippet', () => {
+      plugin.on('touchTap', ({ hold, tapPos }) => {
+        console.log(`touch screen tapped at (${tapPos[0]}, ${tapPos[1]}), ${hold ? 'was' : 'was not'} held!`);
+      });
+    });
     test('the websocketOpen snippet', () => {
       plugin.on('websocketOpen', ({ uuid }) => console.log(`websocket opened for uuid/context: ${uuid}`));
     });
@@ -108,6 +123,12 @@ describe('Tests that the snippets in the Readme.md dont throw errors', () => {
     });
     test('the SendToPropertyInspectorEvent snippet', () => {
       plugin.sendToPropertyInspector('context', { some: 'data' });
+    });
+    test('the SetFeedbackEvent snippet', () => {
+      plugin.setFeedback({ title: 'Hello, world!' }, 'context');
+    });
+    test('the SetFeedbackLayout snippet', () => {
+      plugin.setFeedbackLayout('layouts/layoutv2.json', 'context');
     });
     test('the SetImageEvent snippet', () => {
       plugin.setImage('imagedataAsBase64', 'context');

--- a/yarn.lock
+++ b/yarn.lock
@@ -801,12 +801,12 @@
     "@semantic-release/git" "^10.0.1"
     conventional-changelog-conventionalcommits "^5.0.0"
 
-"@rweich/streamdeck-events@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@rweich/streamdeck-events/-/streamdeck-events-4.0.0.tgz#8144d12ee142cdce88f2e74735267228fa70eccc"
-  integrity sha512-z2ac2shyePVCUqpz8ynHfdyivbd6/Ec9+RuokvjC2OzDPnE4xkso3gw/+fHPiiAwmy1xDqMjFmw2Zg8Y/2aAcg==
+"@rweich/streamdeck-events@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rweich/streamdeck-events/-/streamdeck-events-4.1.0.tgz#0710901de85748f43f0dd22c8e5298c75023031f"
+  integrity sha512-Ted4xQfYHueKy8GhNB/sqf0ZkcA/e+z4aRsUKSAuxXBGVaXEMAmi09kzP79+YlIZ6p/sMRTDgME48shX95+RoQ==
   dependencies:
-    "@sinclair/typebox" "0.24.48"
+    "@sinclair/typebox" "0.24.49"
     ajv "^8.6.2"
 
 "@semantic-release/changelog@^6.0.1":
@@ -908,10 +908,15 @@
     lodash "^4.17.4"
     read-pkg-up "^7.0.0"
 
-"@sinclair/typebox@0.24.48", "@sinclair/typebox@^0.24.48":
-  version "0.24.48"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.48.tgz#bd558c6059df563d49a4d94df8e8e0510b662e3f"
-  integrity sha512-WPGpRNHbkOsfBDmh8QHU7a5NWzEuYNThST8x1cISvX0RpP+1+V8zjuJqNwGJkHGIlhdIIhv6qVYqXz2q5/gjAA==
+"@sinclair/typebox@0.24.49":
+  version "0.24.49"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.49.tgz#7a3a5569fe9e4faa47d8019246d37541c2d7a058"
+  integrity sha512-qWgJVeCThMWTJSAZHyHDlHBkJY0LARFoq/96RH4oIFAwJptMwB3Isq62c4zRVRIAF2r4RMOc2WOhtOLj5C4InA==
+
+"@sinclair/typebox@^0.24.49":
+  version "0.24.51"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.51.tgz#645f33fe4e02defe26f2f5c0410e1c094eac7f5f"
+  integrity sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==
 
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
   version "1.8.3"


### PR DESCRIPTION
And the other side of the equation!

This should cover everything necessary to add SD+ bindings to streamdeck-ts and expose it for use everywhere, and should have tests to boot.

Given I put a fair bit of documentation into streamdeck-events rather than here, I tried to keep duplication to a relative minimum while also still keeping this side _useful_. I'm not too satisfied with the result, but it should be workable especially when combined with type-hinting and official docs (once they're released).