### PR TITLE
Update streamdeck-ts to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@rweich/streamdeck-events": "^4.1.0",
+    "@rweich/streamdeck-events": "^5.0.0",
     "@sinclair/typebox": "^0.24.49",
     "ajv": "^8.9.0",
     "eventemitter3": "^4.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -801,10 +801,10 @@
     "@semantic-release/git" "^10.0.1"
     conventional-changelog-conventionalcommits "^5.0.0"
 
-"@rweich/streamdeck-events@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@rweich/streamdeck-events/-/streamdeck-events-4.1.0.tgz#0710901de85748f43f0dd22c8e5298c75023031f"
-  integrity sha512-Ted4xQfYHueKy8GhNB/sqf0ZkcA/e+z4aRsUKSAuxXBGVaXEMAmi09kzP79+YlIZ6p/sMRTDgME48shX95+RoQ==
+"@rweich/streamdeck-events@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@rweich/streamdeck-events/-/streamdeck-events-5.0.0.tgz#3fee98cb7eb7f28bfe864b3bcbc281204386ab2c"
+  integrity sha512-i3BUQs8UnIWldx5jxWi1Ex98UwqmSiEZ20n5D2aAddVZDl8/iq5XEF+9jIyBO2VSfHgN8wo+R2CYsttA/LAISg==
   dependencies:
     "@sinclair/typebox" "0.24.49"
     ajv "^8.6.2"


### PR DESCRIPTION
And the other side of https://github.com/rweich/streamdeck-events/pull/30. This should make `streamdeck-ts` Fully Compliant With The Official Documentation (subject to notes discussed in the events repo).

This change only bumps the `streamdeck-events` version to 5.0.0. As most dependents of this library use `streamdeck-events` transitively, I'm electing to make this a breaking change to comply with the Principle of Least Astonishment.